### PR TITLE
Add Docker cleanup workflow

### DIFF
--- a/.github/workflows/docker-cleanup.yml
+++ b/.github/workflows/docker-cleanup.yml
@@ -10,9 +10,9 @@ jobs:
   delete_versions:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/delete-package-versions@v5
-      with: 
-        package-name: 'wakelock'
-        package-type: 'container'
-        min-versions-to-keep: 10
-        delete-only-untagged-versions: false
+      - uses: actions/delete-package-versions@v5
+        with:
+          package-name: 'wakelock'
+          package-type: 'container'
+          min-versions-to-keep: 10
+          delete-only-untagged-versions: false

--- a/.github/workflows/docker-cleanup.yml
+++ b/.github/workflows/docker-cleanup.yml
@@ -1,0 +1,18 @@
+name: Docker cleanup
+
+on:
+  workflow_dispatch:
+
+permissions:
+  packages: write
+
+jobs:
+  delete_versions:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/delete-package-versions@v5
+      with: 
+        package-name: 'wakelock'
+        package-type: 'container'
+        min-versions-to-keep: 10
+        delete-only-untagged-versions: false


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for automated Docker image cleanup. The workflow allows maintainers to easily remove old versions of the `wakelock` container package via a manual trigger.

Workflow automation:

* Added a `.github/workflows/docker-cleanup.yml` workflow that uses the `actions/delete-package-versions` action to delete old versions of the `wakelock` container, keeping the latest 10 versions and allowing deletion of both tagged and untagged images.